### PR TITLE
Add EvoTokenDLM and DiSE (ACL 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Make a PR if you want to include your paper on this list or if you've found a co
 - **Discovering Mathematical Equations with Diffusion Language Model** — *September 16, 2025* <i><a href="https://arxiv.org/abs/2509.13136" target="_blank">arXiv</a></i>
 
 ## Analysis/Position Papers
+- **Efficient Self-Evaluation for Diffusion Language Models via Sequence Regeneration** — *March 3, 2026* (ACL 2026) <i><a href="https://arxiv.org/abs/2603.02760" target="_blank">arXiv</a></i>
 - **On the Role of Discreteness in Diffusion LLMs** — *December 27, 2025* <i><a href="https://arxiv.org/abs/2512.22630" target="_blank">arXiv</a></i>
 - **Understanding the Limitations of Diffusion LLMs through a Probabilistic Perspective** - *November 25, 2025* <i><a href="https://www.notion.so/Understanding-the-Limitations-of-Diffusion-LLMs-through-a-Probabilistic-Perspective-2ae0ba07baa88053b838d5bf0b0aad41#2af0ba07baa880c29fc4c8c198244cc8" target="_blank">Notion</a></i>
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Make a PR if you want to include your paper on this list or if you've found a co
 - **Diffusion Beats Autoregressive in Data-Constrained Settings** — *July 21, 2025* <i><a href="https://arxiv.org/abs/2507.15857" target="_blank">arXiv</a></i>
 
 ## Architecture
+- **Beyond Hard Masks: Progressive Token Evolution for Diffusion Language Models** — *January 16, 2026* (ACL 2026) <i><a href="https://arxiv.org/abs/2601.07351" target="_blank">arXiv</a>, <a href="https://github.com/aim-uofa/EvoTokenDLM" target="_blank">Code</a></i>
 - **CANDI: Hybrid Discrete-Continuous Diffusion Models** - *October 26, 2025* <i><a href="https://arxiv.org/abs/2510.22510" target="_blank">arXiv</a></i>
 - **Any-Order GPT as Masked Diffusion Model: Decoupling Formulation and Architecture** — *June 24, 2025* <i><a href="https://arxiv.org/abs/2506.19935" target="_blank">arXiv</a></i>
 
@@ -56,6 +57,7 @@ Make a PR if you want to include your paper on this list or if you've found a co
 ## Decoding Strategies
 - **LogicDiff: Logic-Guided Denoising Improves Reasoning in Masked Diffusion Language Models** — *March 24, 2026* <i><a href="https://arxiv.org/pdf/2603.26771" target="_ blank">arXiv</a></i>
 - **GeoBlock: Inferring Block Granularity from Dependency Geometry in Diffusion Language Models** — *March 4, 2026* <i><a href="https://arxiv.org/pdf/2603.26675" target="_ blank">arXiv</a></i>
+- **Efficient Self-Evaluation for Diffusion Language Models via Sequence Regeneration** — *March 3, 2026* (ACL 2026) <i><a href="https://arxiv.org/abs/2603.02760" target="_blank">arXiv</a></i>
 - **One Token Is Enough: Improving Diffusion Language Models with a Sink Token** — *January 27, 2026* <i><a href="https://arxiv.org/abs/2601.19657v2" target="_ blank">arXiv</a></i>
 - **Deferred Commitment Decoding for Diffusion Language Models with Confidence-Aware Sliding Windows** — *January 5, 2026* <i><a href="https://arxiv.org/abs/2601.02076" target="_ blank">arXiv</a></i>
 - **Activation Steering for Masked Diffusion Language Models** — *December 30, 2025* <i><a href="https://arxiv.org/abs/2512.24143" target="_ blank">arXiv</a></i>


### PR DESCRIPTION
Adds two ACL 2026 main-conference papers on diffusion language models:

- **EvoTokenDLM** (arXiv:2601.07351) — replaces hard binary masks with evolving soft-token distributions; continuous trajectory supervision. Code: https://github.com/aim-uofa/EvoTokenDLM → **Architecture**
- **DiSE** (arXiv:2603.02760) — training-free self-evaluation via token-regeneration probability; enables flexible-length generation. → **Decoding Strategies**

Entries follow the existing bold-title + italic-date format. Newest-first ordering preserved within each section.

Disclosure: I am a co-author on both papers.