### PR TITLE
Add dlmserve to LibrariesAdd dlmserve to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Make a PR if you want to include your paper on this list or if you've found a co
 ![Papers by Category Radar](graphics/papers_by_category_radar.png)
 
 ## Libraries
+- **dlmserve: First OSS Serving Engine for Diffusion Language Models** - *May 25, 2026* <i><a href="https://github.com/iOptimizeThings/dlmserve" target="_blank">GitHub</a></i>
 - **DiRL: An Efficient Training Framework for Diffusion Language Models** - *November 18, 2025* <i><a href="https://github.com/OpenMOSS/DiRL" target="_blank">GitHub</a></i>
 - **dLLM: Simple Diffusion Language Modeling** - *October 11, 2025* <i><a href="https://github.com/ZHZisZZ/dllm" target ="_blank">GitHub</a></i>
 


### PR DESCRIPTION
Adds dlmserve to the Libraries section.

  - Repo: https://github.com/iOptimizeThings/dlmserve
  - License: MIT
  - First open-source serving engine for diffusion language models (LLaDA family)
  - OpenAI-compatible HTTP, step-level continuous batching (2.5x HF throughput at batch=4), optional LocalLeap acceleration (~1.8x extra)
  - Token-identical to the reference HF loop at temperature=0

Thanks for maintaining this list!